### PR TITLE
Initialize problem

### DIFF
--- a/lalr.scm
+++ b/lalr.scm
@@ -1973,6 +1973,9 @@
   (lambda (lexerp errorp)
     (set! ___errorp errorp)
     (set! ___lexerp lexerp)
+    (set! ___input #f)
+    (set! ___curr-input #f)
+    (set! ___reuse-input #f)
     (___initstack)
     (___run)))
 

--- a/tests/run-gauche-test.sh
+++ b/tests/run-gauche-test.sh
@@ -7,6 +7,7 @@ for item in \
     test-glr-basics-03.scm              \
     test-glr-basics-04.scm              \
     test-glr-basics-05.scm              \
+    test-glr-basics-06.scm              \
     test-glr-associativity.scm          \
     test-glr-script-expression.scm      \
     test-glr-single-expressions.scm     \
@@ -16,6 +17,7 @@ for item in \
     test-lr-basics-03.scm               \
     test-lr-basics-04.scm               \
     test-lr-basics-05.scm               \
+    test-lr-basics-06.scm               \
     test-lr-error-recovery-01.scm       \
     test-lr-error-recovery-02.scm       \
     test-lr-no-clause.scm               \

--- a/tests/run-guile-test.sh
+++ b/tests/run-guile-test.sh
@@ -7,6 +7,7 @@ for item in \
     test-glr-basics-03.scm              \
     test-glr-basics-04.scm              \
     test-glr-basics-05.scm              \
+    test-glr-basics-06.scm              \
     test-glr-associativity.scm          \
     test-glr-script-expression.scm      \
     test-glr-single-expressions.scm     \
@@ -16,6 +17,7 @@ for item in \
     test-lr-basics-03.scm               \
     test-lr-basics-04.scm               \
     test-lr-basics-05.scm               \
+    test-lr-basics-06.scm               \
     test-lr-error-recovery-01.scm       \
     test-lr-error-recovery-02.scm       \
     test-lr-no-clause.scm               \

--- a/tests/test-glr-basics-06.scm
+++ b/tests/test-glr-basics-06.scm
@@ -1,0 +1,42 @@
+;;; test-glr-basics-06.scm --
+;;
+;; Derived from test-glr-basics-06.scm --
+;; Check if parser initializes all of its local
+;; variables, so that it be called multiple times.
+;;
+
+(load "common-test.scm")
+
+(define (doit . tokens)
+  (let ((parser (lalr-parser (expect: 0)
+			     (driver: glr)
+			     (A)
+			     (e (e A) : (cons $2 $1)
+				(A)   : (list $1)
+				()    : (list 0)))))
+    (parser (make-lexer tokens) error-handler)
+    (parser (make-lexer tokens) error-handler)))
+
+(check
+    (doit)
+  => '((0)))
+
+(check
+    (doit (make-lexical-token 'A #f 1))
+  => '((1 0)
+       (1)))
+
+(check
+    (doit (make-lexical-token 'A #f 1)
+	  (make-lexical-token 'A #f 2))
+  => '((2 1 0)
+       (2 1)))
+
+(check
+    (doit (make-lexical-token 'A #f 1)
+	  (make-lexical-token 'A #f 2)
+	  (make-lexical-token 'A #f 3))
+  => '((3 2 1 0)
+       (3 2 1)))
+
+;;; end of file

--- a/tests/test-lr-basics-06.scm
+++ b/tests/test-lr-basics-06.scm
@@ -1,0 +1,40 @@
+;;; test-lr-basics-06.scm --
+;;
+;; Derived from test-lr-basics-05.scm.
+;; Check if parser initializes all of its local
+;; variables, so that it be called multiple times.
+;;
+
+(load "common-test.scm")
+
+(define (doit . tokens)
+  (let ((parser (lalr-parser (expect: 0)
+			     (A)
+			     (e (e A) : (cons $2 $1)
+				(A)   : (list $1)
+				()    : 0))))
+    (parser (make-lexer tokens) error-handler)
+    (parser (make-lexer tokens) error-handler)
+    ))
+    
+
+(check
+    (doit)
+  => 0)
+
+(check
+    (doit (make-lexical-token 'A #f 1))
+  => '(1))
+
+(check
+    (doit (make-lexical-token 'A #f 1)
+	  (make-lexical-token 'A #f 2))
+  => '(2 1))
+
+(check
+    (doit (make-lexical-token 'A #f 1)
+	  (make-lexical-token 'A #f 2)
+	  (make-lexical-token 'A #f 3))
+  => '(3 2 1))
+
+;;; end of file


### PR DESCRIPTION
Hi, 
I found ___input in lr-driver is not initialized at runtime.
Without this, I can not call a parser made by lalr-parser multiple times.
(See basic-06-test in this PR)
I added the test  for both lr and glr driver. Although glr-driver is fine.
